### PR TITLE
Use specified cache directory and timeout for the HTTP layer.

### DIFF
--- a/sword2/http_layer.py
+++ b/sword2/http_layer.py
@@ -54,8 +54,8 @@ class HttpLib2Response(HttpResponse):
         return self.resp.keys()
 
 class HttpLib2Layer(HttpLayer):
-    def __init__(self, cache_dir, timeout=30):
-        self.h = httplib2.Http(".cache", timeout=30.0)
+    def __init__(self, cache_dir=".cache", timeout=30.0):
+        self.h = httplib2.Http(cache_dir, timeout=timeout)
         
     def add_credentials(self, username, password):
         self.h.add_credentials(username, password)


### PR DESCRIPTION
Our sworduploader was timing out on large uploads so we wanted to allow the timeout for the connection to the server to be given as a parameter. HttpLib2Layer takes parameters of cache folder and timeout value, but it is then initialised with fixed values of ".cache" and 30.0 rather than using the parameter values given. This change uses the values passed in.
