### PR TITLE
Bug Fixes and Updates for DVN Consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ dist/
 sword2.egg-info/
 *.pyc
 *.py~
-
+*.conf
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ sword2.egg-info/
 *.pyc
 *.py~
 
+
+.DS_Store

--- a/sword2/atom_objects.py
+++ b/sword2/atom_objects.py
@@ -156,7 +156,7 @@ class Entry(object):
         xmlns:dcterms="http://purl.org/dc/terms/">
     <generator uri="http://bitbucket.org/beno/python-sword2" version="%s"/>
 </entry>""" % __version__
-    def __init__(self, **kw):
+    def __init__(self, atomEntryXml=None, **kw):
         """Create a basic `Entry` document, setting the generator and a timestamp for the updated element value.
         
         Any keyword parameters passed in will be passed to the add_fields method and added to the entry
@@ -164,7 +164,7 @@ class Entry(object):
         
         # create a namespace map which we'll use in all of the elements
         self.nsmap = {"dcterms" : "http://purl.org/dc/terms/", "atom" : "http://www.w3.org/2005/Atom"}
-        self.entry = etree.fromstring(self.bootstrap)
+        self.entry = etree.fromstring(self.bootstrap if not atomEntryXml else atomEntryXml)
         if not 'updated' in kw.keys():
             kw['updated'] = datetime.now().isoformat()
         self.add_fields(**kw)

--- a/sword2/connection.py
+++ b/sword2/connection.py
@@ -25,6 +25,7 @@ from compatible_libs import etree
 
 # import httplib2
 import http_layer
+import urllib
 
 class Connection(object):
     """
@@ -587,7 +588,7 @@ Loading in a locally held Service Document:
             headers['Content-Type'] = str(mimetype)
             headers['Content-MD5'] = str(md5sum)
             headers['Content-Length'] = str(f_size)
-            headers['Content-Disposition'] = "attachment; filename=%s" % filename   # TODO: ensure filename is ASCII
+            headers['Content-Disposition'] = "attachment; filename=%s" % urllib.quote(filename)
             if packaging is not None:
                 headers['Packaging'] = str(packaging)
             

--- a/sword2/connection.py
+++ b/sword2/connection.py
@@ -128,7 +128,8 @@ Please see the testsuite for this class for more examples of the sorts of transa
                        error_response_raises_exceptions=True,
                        
                        # http layer implementation if different from default
-                       http_impl=None):
+                       http_impl=None,
+                       ca_certs=None):
         """
 Creates a new Connection object.
 
@@ -215,7 +216,7 @@ Loading in a locally held Service Document:
         # set the http layer
         if http_impl is None:
             conn_l.info("Loading default HTTP layer")
-            self.h = http_layer.HttpLib2Layer(".cache", timeout=30.0)
+            self.h = http_layer.HttpLib2Layer(".cache", timeout=30.0, ca_certs=ca_certs)
         else:
             conn_l.info("Using provided HTTP layer")
             self.h = http_impl

--- a/sword2/connection.py
+++ b/sword2/connection.py
@@ -257,7 +257,7 @@ Loading in a locally held Service Document:
         
         `self.raise_except` can be altered at any time to affect this methods behaviour."""
         if self.raise_except:
-            raise cls(resp)
+            raise cls(resp, content)
         else:
             # content type can contain both the mimetype and the charset (e.g. text/xml; charset=utf-8)
             if resp['content-type'].startswith("text/xml") or resp['content-type'].startswith("application/xml"):
@@ -312,7 +312,7 @@ Loading in a locally held Service Document:
             conn_l.error("Server error occured. Response headers from the server:\n%s" % resp)
             return self._return_error_or_exception(ServerError, resp, content)
         else:
-            conn_l.error("Unknown error occured. Response headers from the server:\n%s" % resp)
+            conn_l.error("Unknown error occured. Response headers from the server:\n%s\n%s" % (resp, content))
             return self._return_error_or_exception(HTTPResponseError, resp, content)
     
     def _cache_deposit_receipt(self, d):

--- a/sword2/exceptions.py
+++ b/sword2/exceptions.py
@@ -6,8 +6,9 @@ Provides various Exception classes to match HTTP error code responses.
 
 class HTTPResponseError(Exception):
     """Generic exception for http codes greater than 399 and less than 599 """
-    def __init__(self, response=None):
+    def __init__(self, response=None, content=None):
         self.response = response
+        self.content = content
         
 class ServerError(HTTPResponseError):
     """ for http error codes 500 and up """

--- a/sword2/http_layer.py
+++ b/sword2/http_layer.py
@@ -1,3 +1,4 @@
+import json
 from sword2_logging import logging
 http_l = logging.getLogger(__name__)
 
@@ -13,6 +14,9 @@ class HttpResponse(object):
         # status (as an integer)
         # location
         pass
+        
+    def __repr__(self):
+    	return json.dumps(self.__dict__, indent=True)
         
     def get(self, att, default=None):
         # same as __getattr__ but with default return
@@ -54,8 +58,8 @@ class HttpLib2Response(HttpResponse):
         return self.resp.keys()
 
 class HttpLib2Layer(HttpLayer):
-    def __init__(self, cache_dir, timeout=30):
-        self.h = httplib2.Http(".cache", timeout=30.0)
+    def __init__(self, cache_dir, timeout=30, ca_certs=None):
+        self.h = httplib2.Http(".cache", timeout=30.0, ca_certs=ca_certs)
         
     def add_credentials(self, username, password):
         self.h.add_credentials(username, password)

--- a/sword2/service_document.py
+++ b/sword2/service_document.py
@@ -149,7 +149,7 @@ class ServiceDocument(object):
                     for accept in accepts:
                         multipart = accept.get("alternate")
                         if multipart is not None:
-                            if multipart != "multipart-related":
+                            if multipart != "multipart-related" and multipart != "multipart/related":
                                 multipart_accept_valid = False
                                 sd_l.debug("Multipart accept alternate is incorrect: " + str(multipart))
                         else:


### PR DESCRIPTION
We needed to make a few changes at DVN to make this library work with our server implementation:

1) Add support for passing a certificate. Some of our test servers are self-signed, so we can't connect unless we can pass our certificate through to HttpLib.
2) A few updates to .gitignore (these you can take or leave).
3) Add support for creating an Entry object from existing XML. One of our use cases was to take existing Atom Entry XML and create deposit metadata with this XML. Made a small change to __init__ on the Entry class to make this possible. Instead of bootstrapping from the small chunk of predefined XML, we bootstrap from the XML passed to __init__().
4) Dump content of requests on error. Before we were just outputting the headers of the request. However, we put useful information in the content of the request, so we should dump that too for debugging.
5) Add support for "multipart/related". We couldn't connect to DSpace/DASH sword server implementations without adding this line.
6) Add __repr__() method to http_layer.py for debugging purposes.