### PR TITLE
Support UTF8 titles for collections

### DIFF
--- a/sword2/collection.py
+++ b/sword2/collection.py
@@ -30,26 +30,26 @@ class SDCollection(object):
     """
     `Collection` - holds, parses and presents simple attributes with information taken from a collection entry
     within a SWORD2 Service Document.
-    
+
     This will be instanciated by a `sword2.Service_Document` and as such, is unlikely to be called explicitly.
-    
+
     Usage:
-        
+
     >>> from sword2 import SDCollection
     >>> c = SDCollection()
-    
+
     .... pull an `etree.SubElement` from a service document into `collection_node`
-    
+
     >>> c.load_from_etree(collection_node)
     >>> c.collectionPolicy
     "This collection has the following policy for deposits"
     >>> c.title
     "Thesis Deposit"
     """
-    def __init__(self, title=None, 
+    def __init__(self, title=None,
                        href=None,
-                       accept=[], 
-                       accept_multipart=[], 
+                       accept=[],
+                       accept_multipart=[],
                        categories=[],
                        collectionPolicy=None,
                        description = None,
@@ -60,17 +60,17 @@ class SDCollection(object):
                        dom=None):
         """
         Creates a `Collection` object - as used by `sword2.Service_Document`
-        
+
         #BETASWORD2URL
         See http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/trunk/SWORDProfile.html?revision=HEAD#protocoloperations_retreivingservicedocument
         for more details about the SWORD2 Service Document.
-        
+
         Usage:
-        
+
         Read useful information from the attributes of this object once loaded.
-        
+
         Attributes::
-        
+
         title                --  <atom:title> - Title of collection, (`str`)
         href                 --  <collection href=... > - Collection IRI (`str`)
         accept               --  <accept>*</accept> - the formats which this collection can take in (`list` of `str`)
@@ -81,16 +81,16 @@ class SDCollection(object):
         description          --  <dcterms:description> - Collection descriptive text (`str`)
         mediation            --  <sword:mediation> - Support for mediated deposit (`True` or `False`)
         treatment            --  <sword:treatment> - from the SWORD2 specifications:
-                                            ".. either a human-readable statement describing treatment the deposited resource 
+                                            ".. either a human-readable statement describing treatment the deposited resource
                                             has received or a IRI that dereferences to such a description."
         acceptPackaging      --  <sword:acceptPackaging> - Accepted package types (`list` of `str`)
                                             from the SWORD2 specifications: "The value SHOULD be a IRI for a known packaging format"
         service              --  <sword:service> - References to nested service descriptions (`list` of `str`)
-        
+
         Example XML fragment that is expected:  (xmlns="http://www.w3.org/2007/app")
-            
+
         ...
-        
+
         <collection href="http://swordapp.org/col-iri/43">
             <atom:title>Collection 43</atom:title>
             <accept>*/*</accept>
@@ -104,19 +104,19 @@ class SDCollection(object):
             <sword:service>http://swordapp.org/sd-iri/e4</sword:service>
         </collection>
         ...
-        
+
         Parsing this fragment:
-        
+
         Again, this step is done by the `sword2.Service_Document`, but if the above XML was in the `doc` variable:
-        
+
             # Get an etree-compatible library, such as from `lxml.etree`, `xml.etree` or `elementtree.ElementTree`
             >>> from sword2.compatible_libs import etree
             >>> from sword2 import SDCollection
             >>> dom = etree.fromstring(doc)
-        
+
             # create an `SDCollection` instance from this XML document
             >>> c = SDCollection(dom = dom)
-        
+
             # query it
             >>> c.treatment
             "Treatment description"
@@ -125,7 +125,7 @@ class SDCollection(object):
             ["http://swordapp.org/sd-iri/e4"]
             >>> c.accept
             ["*/*"]
-        
+
         """
         # APP/Atom
         self.title = title
@@ -144,7 +144,7 @@ class SDCollection(object):
             # Allow constructor variables to provide defaults, but information within the
             # XML element overwrites or appends.
             self.load_from_etree(dom)
-    
+
     def _reset(self):
         """Blank this instance of `SDCollection`"""
         self.title = None
@@ -159,11 +159,11 @@ class SDCollection(object):
         self.acceptPackaging = []
         self.service = None
         self.categories = []
-    
+
     def load_from_etree(self, collection):
         """
         Parse an `etree.SubElement` into attributes in this object.
-        
+
         Also, caches the most recently used DOM object it is passed in
         `self.dom`
         """
@@ -183,19 +183,19 @@ class SDCollection(object):
             self.categories.append(Category(dom=category_element))
         # SWORD extensions:
         self.collectionPolicy = get_text(collection, NS['sword'] % 'collectionPolicy')
-                
+
         # Mediation: True/False
         mediation = get_text(collection, NS['sword'] % 'mediation')
         self.mediation = mediation.lower() == "true"
-                
-        self.treatment = get_text(collection, NS['sword'] % 'treatment')        
+
+        self.treatment = get_text(collection, NS['sword'] % 'treatment')
         self.description = get_text(collection, NS['dcterms'] % 'abstract')
         self.service = get_text(collection, NS['sword'] % 'service', plural = True)
         self.acceptPackaging = get_text(collection, NS['sword'] % 'acceptPackaging', plural = True)
-        
+
         # Log collection details:
-        coll_l.debug(str(self))
-    
+        coll_l.debug(unicode(self))
+
     def __str__(self):
         """Provides a simple display of the pertinent information in this object suitable for CLI logging."""
         _s = ["Collection: '%s' @ '%s'. Accept:%s" % (self.title, self.href, self.accept)]
@@ -221,7 +221,7 @@ class SDCollection(object):
 
     def to_json(self):
         """Provides a simple means to turn the important parsed information into a simple JSON-encoded form.
-        
+
         NB this uses the attributes of the object, not the cached DOM object, so information can be altered/added
         on the fly."""
         from compatible_libs import json
@@ -249,6 +249,6 @@ class Collection_Feed(object):
         self.feed_iri = feed_iri
         self._cached = []
         self.h = http_client
-        
-            
+
+
 


### PR DESCRIPTION
Fixes logging of collection information, to support non-ascii titles (e.g. such in the case of the French HAL: http://api.archives-ouvertes.fr/docs/sword