### PR TITLE
Draft: Strings need converted to unicode when creating multipart request

### DIFF
--- a/sword2/http_layer.py
+++ b/sword2/http_layer.py
@@ -85,7 +85,7 @@ class PreemptiveBasicAuthHandler(urllib.request.HTTPBasicAuthHandler):
         self.password = password
 
     def http_request(self, request):
-        request.add_header(self.auth_header, 'Basic %s' % base64.b64encode(self.username + ':' + self.password))
+        request.add_header(self.auth_header, 'Basic %s' % base64.b64encode((self.username + ':' + self.password).encode()).decode("utf-8"))
         return request
 
     https_request = http_request

--- a/sword2/utils.py
+++ b/sword2/utils.py
@@ -221,7 +221,10 @@ def create_multipart_related(payloads):
             if hasattr(payload['data'], 'read'):
                 body.append(b64encode(payload['data'].read()))
             else:
-                body.append(b64encode(payload['data']))
+                try:
+                    body.append(b64encode(payload['data']))
+                except TypeError:
+                    body.append(b64encode(payload['data'].encode("utf-8")))
     body.append('--' + BOUNDARY + '--')
     body.append('')
     body_bytes = CRLF.join(body)

--- a/sword2/utils.py
+++ b/sword2/utils.py
@@ -188,7 +188,7 @@ def create_multipart_related(payloads):
     """
     # Generate random boundary code
     # TODO check that it does not occur in the payload data
-    bhash = md5(datetime.now().isoformat()).hexdigest()    # eg 'd8bb3ea6f4e0a4b4682be0cfb4e0a24e'
+    bhash = md5(datetime.now().isoformat().encode()).hexdigest()    # eg 'd8bb3ea6f4e0a4b4682be0cfb4e0a24e'
     BOUNDARY = '===========%s_$' % bhash
     CRLF = '\r\n'   # As some servers might barf without this.
     body = []

--- a/sword2/utils.py
+++ b/sword2/utils.py
@@ -190,7 +190,7 @@ def create_multipart_related(payloads):
     # TODO check that it does not occur in the payload data
     bhash = md5(datetime.now().isoformat().encode()).hexdigest()    # eg 'd8bb3ea6f4e0a4b4682be0cfb4e0a24e'
     BOUNDARY = '===========%s_$' % bhash
-    CRLF = '\r\n'   # As some servers might barf without this.
+    CRLF = b'\r\n'   # As some servers might barf without this.
     body = []
     for payload in payloads:   # predicatable ordering...
         body.append('--' + BOUNDARY)
@@ -213,20 +213,20 @@ def create_multipart_related(payloads):
             body.append('Content-Transfer-Encoding: base64')
             body.append('')
             if hasattr(payload['data'], 'read'):
-                body.append(b64encode(payload['data'].read()))
+                body.append(b64encode(payload['data'].read()).decode())
             else:
-                body.append(b64encode(payload['data']))
+                body.append(b64encode(payload['data']).decode())
         else:
             body.append('')
             if hasattr(payload['data'], 'read'):
-                body.append(b64encode(payload['data'].read()))
+                body.append(b64encode(payload['data'].read()).decode())
             else:
                 try:
-                    body.append(b64encode(payload['data']))
+                    body.append(b64encode(payload['data']).decode())
                 except TypeError:
-                    body.append(b64encode(payload['data'].encode("utf-8")))
+                    body.append(b64encode(payload['data'].encode("utf-8")).decode())
     body.append('--' + BOUNDARY + '--')
     body.append('')
-    body_bytes = CRLF.join(body)
+    body_bytes = CRLF.join([line.encode("utf-8") for line in body])
     content_type = 'multipart/related; boundary="%s"' % BOUNDARY
     return content_type, body_bytes


### PR DESCRIPTION
At two points in the multi-part request creation utility, encoding is missing to allow bytes-consuming functions to run.

[utils.py:191](https://github.com/swordapp/python-client-sword2/blob/master/sword2/utils.py#L191)
```
md5(datetime.now().isoformat()).hexdigest()
```

as DateTime.isoformat() will return a UTF-8 string, and

[utils.py:224](https://github.com/swordapp/python-client-sword2/blob/master/sword2/utils.py#L224)
```
body.append(b64encode(payload['data']))
```

as etree with return a UTF-8 string also.

The PR'd code is a draft to resolve this - if the general approach is considered appropriate, we can update tests/docs and refine for inclusion.